### PR TITLE
Refactored Vagrantfile and site.yml

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -2,6 +2,8 @@
 ---
 - name: Install influxdb server
   hosts: "{{host_inventory}}"
+  vars_files:
+    - vars/influxdb.yml
   vars:
     - combined_package_list: "{{ (default_packages|default([])) | union((install_packages_by_tag|default({})).influxdb|default([])) }}"
   roles:


### PR DESCRIPTION
The changes in this pull request refactor the `Vagrantfile` and `site.yml` file in order to pull in default values for deployment of InfluxDB from the newly created `vars/influxdb.yml` file and to support additional Vagrant flags.  Specifically:

* the `site.yml` file was changed to pull in the `vars/influxdb.yml` file (in order to retrieve the default values for the parameters that *must* be defined to successfully deploy InfluxDB using the Ansible playbook defined in the `site.yml` file)
* Code was added to the `Vagrantfile` to monkey-patch the `OptionParser` class used to parse the command-line flags passed to the `vagrant ...` commands; the modified code passes any unrecognized options on to the underlying `vagrant` command so that the `--no-provision` flag can be passed to a `vagrant up ...` command to create, but not provision a new virtual machine.

With these changes in place, we should be ready to wrap the deployment of InfluxDB via Vagrant in the same install wrapper that we are currently using to deploy apps to machines hosted in AWS.